### PR TITLE
Revamp transactions

### DIFF
--- a/client/core/src/core.rs
+++ b/client/core/src/core.rs
@@ -9,7 +9,7 @@ use crate::crypto::Crypto;
 use crate::hash_vectors::{CommonPayload, HashVectors, ValidationPayload};
 use crate::server_comm::{
     EncryptedCommonPayload, EncryptedInboxMessage, EncryptedOutboxMessage,
-    EncryptedPerRecipientPayload, Event, OutboxMessages, ServerComm, ToDelete,
+    EncryptedPerRecipientPayload, Event, EncryptedOutboxMessages, ServerComm, ToDelete,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -248,7 +248,7 @@ impl<C: CoreClient> Core<C> {
 
         // add "main" message with all those w/access to metadata
         outgoing_messages.push(encrypted_message_with_metadata);
-        let outbox_messages = OutboxMessages {
+        let outbox_messages = EncryptedOutboxMessages {
             messages: outgoing_messages,
         };
 

--- a/client/core/src/core.rs
+++ b/client/core/src/core.rs
@@ -143,6 +143,8 @@ impl<C: CoreClient> Core<C> {
         self.crypto.get_idkey()
     }
 
+
+    // TODO: change message to be a collection of messages
     pub async fn send_message(
         &self,
         dst_idkeys: Vec<String>,

--- a/client/core/src/core.rs
+++ b/client/core/src/core.rs
@@ -9,7 +9,7 @@ use crate::crypto::Crypto;
 use crate::hash_vectors::{CommonPayload, HashVectors, ValidationPayload};
 use crate::server_comm::{
     EncryptedCommonPayload, EncryptedInboxMessage, EncryptedOutboxMessage,
-    EncryptedPerRecipientPayload, Event, ServerComm, ToDelete,
+    EncryptedPerRecipientPayload, Event, OutboxMessages, ServerComm, ToDelete,
 };
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -143,11 +143,11 @@ impl<C: CoreClient> Core<C> {
         self.crypto.get_idkey()
     }
 
-
     // TODO: change message to be a collection of messages
     pub async fn send_message(
         &self,
-        dst_idkeys: Vec<String>,
+        dst_idkeys_w_metadata: Vec<String>,
+        dst_idkeys_wo_metadata: Vec<String>, //TODO: change to option
         payload: &String,
     ) -> reqwest::Result<reqwest::Response> {
         loop {
@@ -165,8 +165,12 @@ impl<C: CoreClient> Core<C> {
         //println!("...TRYING SEND LOCK...");
         let mut hash_vectors_guard = self.hash_vectors.lock().await;
         //println!("...GOT SEND LOCK...");
+        let mut compose_dst_idkeys = Vec::new();
+        compose_dst_idkeys.append(&mut dst_idkeys_w_metadata.clone());
+        compose_dst_idkeys.append(&mut dst_idkeys_wo_metadata.clone());
+        // still need to get validation payload for all
         let (common_payload, val_payloads) = hash_vectors_guard
-            .prepare_message(dst_idkeys.clone(), payload.to_string());
+            .prepare_message(compose_dst_idkeys, payload.to_string());
 
         // FIXME What if common_payloads are identical?
         // If they're identical here, they can trigger a reordering detection,
@@ -195,6 +199,9 @@ impl<C: CoreClient> Core<C> {
             .crypto
             .symmetric_encrypt(CommonPayload::to_string(&common_payload));
 
+        // vector of messages to be sequences sequentially
+        let mut outgoing_messages = Vec::new();
+
         // Can't use .iter().map().collect() due to async/await
         let mut encrypted_per_recipient_payloads = HashMap::new();
         for (idkey, val_payload) in val_payloads {
@@ -211,18 +218,38 @@ impl<C: CoreClient> Core<C> {
                 )
                 .await;
 
-            // Ensure we're never encrypting to the same key twice
-            assert!(encrypted_per_recipient_payloads
-                .insert(
+            // if part of reader-only, don't include in main message
+            if dst_idkeys_w_metadata.contains(&idkey) {
+                // Ensure we're never encrypting to the same key twice
+                assert!(encrypted_per_recipient_payloads
+                    .insert(
+                        idkey.clone(),
+                        EncryptedPerRecipientPayload { c_type, ciphertext }
+                    )
+                    .is_none());
+            } else {
+                // TODO: check we didn't insert multiple times?
+                let mut map = HashMap::new(); // FIXME: change struct so it's not a map!
+                map.insert(
                     idkey,
-                    EncryptedPerRecipientPayload { c_type, ciphertext }
-                )
-                .is_none());
+                    EncryptedPerRecipientPayload { c_type, ciphertext },
+                );
+                outgoing_messages.push(EncryptedOutboxMessage {
+                    enc_common: EncryptedCommonPayload::from_bytes(&common_ct),
+                    enc_recipients: map,
+                })
+            }
         }
 
-        let encrypted_message = EncryptedOutboxMessage {
+        let encrypted_message_with_metadata = EncryptedOutboxMessage {
             enc_common: EncryptedCommonPayload::from_bytes(&common_ct),
             enc_recipients: encrypted_per_recipient_payloads,
+        };
+
+        // add "main" message with all those w/access to metadata
+        outgoing_messages.push(encrypted_message_with_metadata);
+        let outbox_messages = OutboxMessages {
+            messages: outgoing_messages,
         };
 
         // loop until front of queue is ready to send
@@ -244,7 +271,7 @@ impl<C: CoreClient> Core<C> {
             .await
             .as_ref()
             .unwrap()
-            .send_message(&encrypted_message)
+            .send_message(&outbox_messages)
             .await
     }
 

--- a/client/core/src/server_comm.rs
+++ b/client/core/src/server_comm.rs
@@ -426,6 +426,11 @@ pub struct EncryptedOutboxMessage {
     pub enc_recipients: HashMap<String, EncryptedPerRecipientPayload>,
 }
 
+#[derive(Debug, Serialize, Clone)]
+pub struct OutboxMessages {
+    pub messages: Vec<EncryptedOutboxMessage>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct EncryptedInboxMessage {
     pub sender: String,
@@ -647,7 +652,7 @@ impl<C: CoreClient> ServerComm<C> {
 
     pub async fn send_message(
         &self,
-        batch: &EncryptedOutboxMessage,
+        batch: &OutboxMessages,
     ) -> Result<Response> {
         self.client
             .post(self.base_url.join("/message").expect("").as_str())

--- a/client/core/src/server_comm.rs
+++ b/client/core/src/server_comm.rs
@@ -427,7 +427,7 @@ pub struct EncryptedOutboxMessage {
 }
 
 #[derive(Debug, Serialize, Clone)]
-pub struct OutboxMessages {
+pub struct EncryptedOutboxMessages {
     pub messages: Vec<EncryptedOutboxMessage>,
 }
 
@@ -652,7 +652,7 @@ impl<C: CoreClient> ServerComm<C> {
 
     pub async fn send_message(
         &self,
-        batch: &OutboxMessages,
+        batch: &EncryptedOutboxMessages,
     ) -> Result<Response> {
         self.client
             .post(self.base_url.join("/message").expect("").as_str())

--- a/client/merged-serializable-noise-kv/src/client.rs
+++ b/client/merged-serializable-noise-kv/src/client.rs
@@ -474,6 +474,7 @@ impl NoiseKVClient {
 
     /* Sending-side function */
 
+    // TODO: change message to be a collection of messages
     async fn send_message(
         &self,
         dst_idkeys: Vec<String>,
@@ -1429,6 +1430,7 @@ impl NoiseKVClient {
         self.initiate_transaction(self.idkey(), ops, prev_seq_number);
     }
 
+    // TODO: change message to be a collection of messages
     async fn send_or_add_to_txn(
         &self,
         dst_idkeys: Vec<String>,
@@ -1622,6 +1624,7 @@ impl NoiseKVClient {
 
         // includes idkeys of _all_ permissions
         // (including data-only readers)
+        // TODO make separate for read-only memebers of txn
         self.send_or_add_to_txn(
                 device_ids.clone(),
                 &Operation::UpdateData(data_id, basic_data)


### PR DESCRIPTION
- Allow propagation transaction writes to readers without exposing the entire recipients list
- Change client-server protocol to accept a list of previous type of messages
- Introduce timeouts for transactions (commit messages received after timeout delta from prepare sequence number are invalid)